### PR TITLE
Map/reduce part deduplication

### DIFF
--- a/bin/watchbot-progress.js
+++ b/bin/watchbot-progress.js
@@ -17,10 +17,11 @@ var help = `
     - set-metadata: set arbitrary metadata on the job record
     - complete-part: complete a single part
     - fail-job: mark a job as a failure
+    - reduce-sent: mark a job as having its reduce step taken
 
   OPTIONS:
     -t, --total     (for set-total) the total number of parts in a job
-    -p, --part      (for complete-part) the part number to mark as complete
+    -p, --part      (for complete-part or status) the part number to mark as complete or check for completeness
     -m, --metadata  (for set-metadata) the JSON metadata object to store
     -r, --reason    (for fail-job) a description of why the job failed
 `;
@@ -51,7 +52,7 @@ var progress;
 try { progress = client(); }
 catch (err) { cli.showHelp(); }
 
-if (command === 'status') return progress.status(jobId, complete);
+if (command === 'status') return progress.status(jobId, cli.flags.part, complete);
 if (command === 'set-total') return progress.setTotal(jobId, cli.flags.total, complete);
 if (command === 'set-metadata') {
   var metadata;
@@ -67,6 +68,7 @@ if (command === 'set-metadata') {
 }
 if (command === 'complete-part') return progress.completePart(jobId, cli.flags.part, complete);
 if (command === 'fail-job') return progress.failJob(jobId, cli.flags.reason, complete);
+if (command === 'reduce-sent') return progress.reduceSent(jobId, complete);
 return cli.showHelp();
 
 function complete(err, data) {

--- a/lib/progress.js
+++ b/lib/progress.js
@@ -56,6 +56,7 @@ function client(table) {
      *
      * @memberof client
      * @param {string} jobId - the identifier for a map-reduce job
+     * @param {number} [part] - the part number to check on
      * @param {function} [callback] - a function that will be called indicating the
      * current job status
      * @returns {promise}
@@ -71,8 +72,23 @@ function client(table) {
      * @example
      * // a job 75% complete which includes metadata
      * { "progress": 0.75, "metadata": { "name": "favorite-map-reduce" } }
+     * @example
+     * // a job 75% complete indicating that the requested part has already been completed
+     * { "progress": 0.75, "partComplete": true }
+     * @example
+     * // a job 100% complete indicating that the reduce step has been taken
+     * { "progress": 0.75, "reduceSent": true }
      */
     status: status.bind(null, dyno),
+
+    /**
+     * Flag a job record to indicate that a reduce step has been taken.
+     *
+     * @param {string} jobId - the identifier for a map-reduce job
+     * @param {function} [callback] - a function that will be called when the flag has been set
+     * @returns {promise}
+     */
+    reduceSent: reduceSent.bind(null, dyno),
 
     /**
      * Fail a job
@@ -82,6 +98,7 @@ function client(table) {
      * @param {string} reason - a description of why the job failed
      * @param {function} [callback] - a function that will be called when the reason
      * for the failure has been recorded
+     * @returns {promise}
      */
     failJob: failJob.bind(null, dyno),
 
@@ -151,7 +168,12 @@ function completePart(dyno, jobId, part, callback) {
   });
 }
 
-function status(dyno, jobId, callback) {
+function status(dyno, jobId, part, callback) {
+  if (typeof part === 'function') {
+    callback = part;
+    part = undefined;
+  }
+
   callback = callback || function() {};
 
   return new Promise((resolve, reject) => {
@@ -170,8 +192,33 @@ function status(dyno, jobId, callback) {
         var response = { progress: percent };
         if (item.error) response.failed = item.error;
         if (item.metadata) response.metadata = item.metadata;
+        if (part) response.partComplete = item.parts.values.indexOf(part) === -1;
+        if (item.hasOwnProperty('reduceSent')) response.reduceSent = item.reduceSent;
         callback(null, response);
         resolve(response);
+      }
+    });
+  });
+}
+
+function reduceSent(dyno, jobId, callback) {
+  callback = callback || function() {};
+
+  var params = {
+    Key: { id: jobId },
+    ExpressionAttributeNames: { '#r': 'reduceSent' },
+    ExpressionAttributeValues: { ':r': true },
+    UpdateExpression: 'set #r = :r'
+  };
+
+  return new Promise((resolve, reject) => {
+    dyno.updateItem(params, function(err) {
+      if (err) {
+        callback(err);
+        reject(err);
+      } else {
+        callback();
+        resolve();
       }
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "watchbot-progress",
+  "name": "@mapbox/watchbot-progress",
   "version": "1.0.1",
   "description": "",
   "repository": {


### PR DESCRIPTION
- adds `watchbot.reduceSent()` to record that a reduce action has been taken. This shows up in the outcome from `watchbot.status()`.
- adds optional `part` argument to `watchbot.status()`. This adds an indication to the response telling you whether or not a specific part has been completed already.
- tacked on adding `@mapbox` namespace to the package name

Fixes #5 