### PR TITLE
Fix promise handling in .status()

### DIFF
--- a/lib/progress.js
+++ b/lib/progress.js
@@ -183,7 +183,10 @@ function status(dyno, jobId, part, callback) {
         reject(err);
       } else {
         var item = data.Item;
-        if (!item) return callback(null, { progress: 0 });
+        if (!item) {
+          callback(null, { progress: 0 });
+          return resolve({ progress: 0 });
+        }
 
         var remaining = item.parts ? item.parts.values.length : 0;
         var percent = (item.total - remaining) / item.total;

--- a/test/progress.test.js
+++ b/test/progress.test.js
@@ -377,6 +377,25 @@ dynamodb.test('[progress] status (with reduceSent)', function(assert) {
   });
 });
 
+dynamodb.test('[progress] status (no job yet)', function(assert) {
+  var client = progress(`arn:aws:dynamodb:local:1234567890:table/${dynamodb.tableName}`);
+  var jobId = 'my-job';
+  client.status(jobId, function(err, status) {
+    assert.ifError(err, 'status success');
+    assert.deepEqual(status, { progress: 0 }, 'reports no progress');
+    assert.end();
+  });
+});
+
+dynamodb.test('[progress] status (no job yet, no callback)', function(assert) {
+  var client = progress(`arn:aws:dynamodb:local:1234567890:table/${dynamodb.tableName}`);
+  var jobId = 'my-job';
+  client.status(jobId)
+    .then((status) => assert.deepEqual(status, { progress: 0 }, 'reports no progress'))
+    .catch((err) => assert.ifError(err, 'failed'))
+    .then(() => assert.end());
+});
+
 dynamodb.test('[progress] can read table from env', function(assert) {
   assert.throws(progress, /ProgressTable environment variable is not set/, 'without env an error is thrown');
   process.env.ProgressTable = `arn:aws:dynamodb:local:1234567890:table/${dynamodb.tableName}`;


### PR DESCRIPTION
If `.status()` was called on a record that does not exist, the response was different depending on whether you were using promises or not. This PR just makes sure the responses are identical.