### PR TITLE
Report progress as 0.99 until all parts are complete

### DIFF
--- a/lib/progress.js
+++ b/lib/progress.js
@@ -190,7 +190,10 @@ function status(dyno, jobId, part, callback) {
 
         var remaining = item.parts ? item.parts.values.length : 0;
         var percent = (item.total - remaining) / item.total;
-        percent = Number(percent.toFixed(2));
+        // Limits percent precision to 2 decimal points, but rounds down
+        // to ensure progress does not equal 1 before all parts are complete.
+        // e.g. progress will be reported as 0.99 until all parts are finished.
+        percent = Number((Math.floor(percent * 100)*0.01).toFixed(2));
 
         var response = { progress: percent };
         if (item.error) response.failed = item.error;


### PR DESCRIPTION
Ran into this "bug" - if a job has enough parts, it's possible in `watchbot-progress@master` for `progress` to be reported as `1` even though not all parts are complete.

- I added a failing test to demonstrate this. The setup: 1000 part job, 999 parts are complete. The status of 1000 will be reported as: `{ progress: 1, partComplete: false }`.
- The behavior we want here seems to be some kind of design question consisting of:
  - **The progress is reported with a truncated number of decimals.** This appears to be by design, rationale is not totally clear but probably for some kind of readability/usability/neatness.
  - **In this scenario, should we round down?** I ran into this bug by finding some code written making use of `watchbot-progress` that assumed `progress: 1` was an indication that all jobs were complete. This does seem like a reasonable assumption a developer might make (e.g. 1 means done!) using `watchbot-progress`, rather than thinking of the `progress` key as some kind of lossy, "visualization" representation of progress. With this in mind, I think the answer here needs to be **Yes**.

This PR implements a round-down approach here.

cc @rclark 