### PR TITLE
Get future dyno patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "aws-sdk": "^2.4.11",
     "d3-queue": "^2.0.3",
-    "@mapbox/dyno": "1.4.2",
+    "@mapbox/dyno": "^1.4.2",
     "meow": "^3.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
PR #13 changed `^1.2.0` to `1.4.2` and locked out future dyno patches like https://github.com/mapbox/dyno/pull/154.